### PR TITLE
Remove the verbose environment variable and use a CLI flag instead

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"github.com/zeromq/goczmq"
 	"os"
 	"os/signal"
@@ -45,15 +46,17 @@ func getTypes() (int, int) {
 
 func main() {
 	incomingBind, outgoingBind := getAddresses()
-	
+
 	incomingType, outgoingType := getTypes()
 
-	verboseLogging := os.Getenv("PROXY_DEBUG")
+	verbosePtr := flag.Bool("verbose", false, "Enable verbose logging")
+
+	flag.Parse()
 
 	// Construct CZMQ proxy
 	proxy := goczmq.NewProxy()
 
-	if verboseLogging == "1" {
+	if *verbosePtr == true {
 		// Set debug logging on
 		proxy.Verbose()
 	}
@@ -74,7 +77,7 @@ func main() {
 
 	// Block until one of the signals listened for is received
 	signalChannel := makeSignalChannel()
-	<- signalChannel
+	<-signalChannel
 
 	// Close proxy and exit
 	proxy.Destroy()


### PR DESCRIPTION
Remove the `PROXY_DEBUG` environment variable and instead use the `-verbose` flag to enable debug logging.

<img width="709" alt="image" src="https://user-images.githubusercontent.com/20439493/52669619-69a55000-2f0e-11e9-8742-90dbe0984ef5.png">

This PR also just changes a couple of linting things.